### PR TITLE
Update test_model_lfw_far.py

### DIFF
--- a/misc/test_model_lfw_far.py
+++ b/misc/test_model_lfw_far.py
@@ -29,16 +29,18 @@ def main():
     model_path = args.model_path
     far_target = args.far_target
 
-    checkpoint = torch.load(model_path)
-    model = Resnet18Triplet(embedding_dimension=checkpoint['embedding_dimension'])
-    model.load_state_dict(checkpoint['model_state_dict'])
-
     flag_gpu_available = torch.cuda.is_available()
 
     if flag_gpu_available:
         device = torch.device("cuda")
     else:
         device = torch.device("cpu")
+        
+    checkpoint = torch.load(model_path, map_location=device)
+    model = Resnet18Triplet(embedding_dimension=checkpoint['embedding_dimension'])
+    model.load_state_dict(checkpoint['model_state_dict'])
+
+    
 
     lfw_transforms = transforms.Compose([
         transforms.Resize(size=224),
@@ -70,8 +72,9 @@ def main():
         progress_bar = enumerate(tqdm(lfw_dataloader))
 
         for batch_index, (data_a, data_b, label) in progress_bar:
-            data_a = data_a.cuda()
-            data_b = data_b.cuda()
+            data_a = data_a.to(device) # data_a = data_a.cuda()
+            data_b = data_b.to(device) # data_b = data_b.cuda()
+            
 
             output_a, output_b = model(data_a), model(data_b)
             distance = l2_distance.forward(output_a, output_b)  # Euclidean distance


### PR DESCRIPTION
Thank you for your repo, I find it very useful. 
I ran the test_model_lfw_far.py on the trained model on CPU and got some crashes, which I fixed to be able to run on my laptop w/o Nvidia (because I want to run it inside a VM):
It crashes on CPU, hence needs to be updated: the device checks must be done before the model is loaded;
also:
```
torch.load(model_path, map_location=device) # we must specify the selected device
data_a = data_a.to(device) # data_a = data_a.cuda() is obsolette
```
Note: I got **weird** results then: TAR: 0.0123+-0.0083 @ FAR: 0.0010 when used the downloaded "model_resnet18_triplet.pt"